### PR TITLE
Correctly identify multiple Feit light bulbs

### DIFF
--- a/lib/list-app.js
+++ b/lib/list-app.js
@@ -58,9 +58,8 @@ async function listApp(config, options) {
 	function printDevices(devices) {
 		// Extract only needed information for easier viewing
 		const devicesStripped = devices.map(device => {
-			return {id: device.devId, key: device.localKey ? device.localKey : devices.localKey};
+			return {id: device.devId ? device.devId : device.gwId, key: device.localKey};
 		});
-
 		// Stop spinner
 		spin.stop();
 
@@ -68,7 +67,6 @@ async function listApp(config, options) {
 		console.log('\n');
 		console.log('Devices(s):'.bold.green);
 		console.log(devicesStripped);
-
 		// Exit
 		// eslint-disable-next-line unicorn/no-process-exit
 		process.exit();

--- a/lib/proxy-rules.js
+++ b/lib/proxy-rules.js
@@ -29,21 +29,15 @@ module.exports = function (callback) {
 function checkForDevice(response) {
 	try {
 		response = JSON.parse(response);
-
 		let devices = false;
-		if (response.result.forEach) {
+		if (response.result.forEach !== undefined) {
 			response.result.forEach(call => {
 				if (call.a === 'tuya.m.my.group.device.list') {
 					devices = call.result;
 				}
 			});
-		} else if (response.result.gateways.forEach) {
-			response.result.gateways.forEach(call => {
-				call.devices.localKey = call.localKey;
-
-				// eslint-disable-next-line prefer-destructuring
-				devices = call.devices;
-			});
+		} else if (response.result.gateways !== undefined) {
+			devices = response.result.gateways;
 		}
 
 		return devices;


### PR DESCRIPTION
It turns out that Feit groups each bulb inside a "gateway" which contains the localKey and has the same ID as the bulb it contains. This should actually list all bulbs instead of just the first one.