### PR TITLE
control: fix check if argument is number

### DIFF
--- a/lib/control.js
+++ b/lib/control.js
@@ -7,7 +7,7 @@ function parseConfig(config, options) {
 		c.badArgument(options);
 	}
 
-	if (Number.isNaN(options.protocolVersion)) {
+	if (Number.isNaN(Number(options.protocolVersion))) {
 		c.badArgument(options);
 	}
 
@@ -66,7 +66,7 @@ async function set(config, options) {
 	}
 
 	if (!options.rawValue) {
-		if (!Number.isNaN(options.set)) {
+		if (!Number.isNaN(Number(options.set))) {
 			options.set = Number.parseInt(options.set, 10);
 		} else if (options.set.toLowerCase() === 'true') {
 			options.set = true;


### PR DESCRIPTION
`Number.isNaN("colour")` returns false so things break.  `+"colour"` is NaN so `Number.isNaN(+"colour")` returns true and things work.  Style checker requires that `+x` be spelled `Number(x)`.

Fixes #75 