### PR TITLE
control.js: get all properties returns json

### DIFF
--- a/lib/control.js
+++ b/lib/control.js
@@ -51,7 +51,7 @@ async function get(config, options) {
 		tuya.disconnect();
 
 		if (options.all) {
-			console.log(properties);
+			console.log(JSON.stringify(properties));
 		} else {
 			console.log(properties.dps[options.dps]);
 		}


### PR DESCRIPTION
When getting all properties for a device, the result should be valid json so that it can be parsed by other tools