### PR TITLE
Add an option to the link command --bind-addr

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,6 +34,7 @@ program
 	.description('link a new device')
 	.option('--ssid <ssid>', 'name of WiFi to connect to')
 	.option('--password <password>', 'password of WiFi')
+	.option('--bind-addr <ip>', 'ip of wireless interface to broadcast on')
 	.option('--api-key [apiKey]', 'your tuya.com API key')
 	.option('--api-secret [apiSecret]', 'your tuya.com API secret')
 	.option('--schema <schema>', 'your tuya.com app identifier')

--- a/lib/link.js
+++ b/lib/link.js
@@ -36,7 +36,8 @@ async function link(config, options) {
 		password: 'examplepassword',
 		schema: options.schema,
 		region: options.region,
-		timezone: options.timezone
+		timezone: options.timezone,
+		bindAddr: options.bindAddr
 	});
 
 	const spinner = ora('Registering devices(s)...').start();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tuya/tuya-connector-nodejs": "^2.0.2",
-        "@tuyapi/link": "^0.3.4",
+        "@tuyapi/link": "^0.4.0",
         "@tuyapi/openapi": "^1.3.0",
         "@tuyapi/stub": "^0.2.0",
         "cli-table3": "^0.6.0",
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@tuyapi/link": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@tuyapi/link/-/link-0.3.4.tgz",
-      "integrity": "sha512-VrIvTuT6QysozA3Q8xW/gfnQxslY+Rnc+pmV1aZDjIRoXZICY3gYOo37gtsPIj0sWsOPTKPzJTbTNDEacQCnLA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tuyapi/link/-/link-0.4.0.tgz",
+      "integrity": "sha512-xgvomLBfXGaMabb3yvieBPWA56UhOBENvPe+zzhILr9U5Mx+I+bOkM3aHBhsRcFruwMHWhTdeMAkclHanVIMvg==",
       "dependencies": {
         "@tuya/tuya-connector-nodejs": "^2.0.3",
         "debug": "^4.1.1",
@@ -2083,7 +2083,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2277,7 +2276,6 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dependencies": {
-        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -6092,7 +6090,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -10049,10 +10046,8 @@
       "dev": true,
       "peer": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -10156,7 +10151,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -11314,9 +11308,9 @@
       }
     },
     "@tuyapi/link": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@tuyapi/link/-/link-0.3.4.tgz",
-      "integrity": "sha512-VrIvTuT6QysozA3Q8xW/gfnQxslY+Rnc+pmV1aZDjIRoXZICY3gYOo37gtsPIj0sWsOPTKPzJTbTNDEacQCnLA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tuyapi/link/-/link-0.4.0.tgz",
+      "integrity": "sha512-xgvomLBfXGaMabb3yvieBPWA56UhOBENvPe+zzhILr9U5Mx+I+bOkM3aHBhsRcFruwMHWhTdeMAkclHanVIMvg==",
       "requires": {
         "@tuya/tuya-connector-nodejs": "^2.0.3",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/TuyaAPI/cli#readme",
   "dependencies": {
     "@tuya/tuya-connector-nodejs": "^2.0.2",
-    "@tuyapi/link": "^0.3.4",
+    "@tuyapi/link": "^0.4.0",
     "@tuyapi/openapi": "^1.3.0",
     "@tuyapi/stub": "^0.2.0",
     "cli-table3": "^0.6.0",


### PR DESCRIPTION
Specifies the interface (by IP) to broadcast the link packets on. Verifies it exists with os.networkInterfaces(). Requires https://github.com/TuyaAPI/link/pull/15